### PR TITLE
Fix sqlite3 installation error in colab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@
 # ===============================
 
 # Core Dependencies
-asyncio
+# asyncio - Already included in Python standard library
 aiohttp>=3.8.0
 pandas>=1.5.0
 numpy>=1.21.0
 requests>=2.28.0
 
 # Database
-sqlite3
+# sqlite3 - Already included in Python standard library
 
 # Machine Learning Core
 scikit-learn>=1.1.0


### PR DESCRIPTION
Remove `sqlite3` and `asyncio` from `requirements.txt`.

These modules are part of Python's standard library and do not need to be installed via pip, causing "No matching distribution found" errors when listed in `requirements.txt`.

---
<a href="https://cursor.com/background-agent?bcId=bc-db15ffbf-aeea-4272-9339-b17d204699bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db15ffbf-aeea-4272-9339-b17d204699bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

