### PR TITLE
Investigate ensemble model calibration failures

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1423,9 +1423,9 @@ class EnsembleModel:
                     calibrated_model = CalibratedClassifierCV(model, method='sigmoid', cv=3)
                     calibrated_model.fit(X_train, y_train)
                     
-                    # Verify calibration was successful
-                    if not hasattr(calibrated_model, 'estimator_') or calibrated_model.estimator_ is None:
-                        raise ValueError("Calibration failed - no estimator found")
+                    # Verify calibration was successful by checking if calibrated_classifiers_ exist
+                    if not hasattr(calibrated_model, 'calibrated_classifiers_') or len(calibrated_model.calibrated_classifiers_) == 0:
+                        raise ValueError("Calibration failed - no calibrated classifiers found")
                     
                     self.logger.info(f"Sử dụng calibrated model cho {model_name}")
                 except Exception as calib_error:


### PR DESCRIPTION
Corrects the calibration success check for `CalibratedClassifierCV` to eliminate false warnings.

The previous check incorrectly looked for the `estimator_` attribute, which `CalibratedClassifierCV` does not possess. Instead, it uses `calibrated_classifiers_` to store the calibrated models, causing `ValueError` to be raised unnecessarily.

---
<a href="https://cursor.com/background-agent?bcId=bc-37ca2ea4-2d9f-40e8-82db-78286e0654ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37ca2ea4-2d9f-40e8-82db-78286e0654ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

