### PR TITLE
Fix pandas datetime type error in data merging

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -4040,9 +4040,9 @@ class TradingBotController:
                                 # Normalize datetime columns for merging - handle timezone mismatch
                                 if 'datetime' in df_with_timeframe.columns:
                                     # Convert both datetime columns to UTC/naive for compatibility
-                                    if pd.api.types.is_datetime64tz_ns_dtype(combined_df['datetime']):
+                                    if isinstance(combined_df['datetime'].dtype, pd.DatetimeTZDtype):
                                         combined_df['datetime'] = combined_df['datetime'].dt.tz_localize(None)
-                                    if pd.api.types.is_datetime64tz_ns_dtype(df_with_timeframe['datetime']):
+                                    if isinstance(df_with_timeframe['datetime'].dtype, pd.DatetimeTZDtype):
                                         df_with_timeframe['datetime'] = df_with_timeframe['datetime'].dt.tz_localize(None)
                                     
                                     # Ensure both datetime columns are the same type


### PR DESCRIPTION
Update pandas datetime type check to resolve `AttributeError` for `is_datetime64tz_ns_dtype`.

The previous method `pd.api.types.is_datetime64tz_ns_dtype` is not available in pandas 2.3.3. The fix replaces it with `isinstance(df['datetime'].dtype, pd.DatetimeTZDtype)`, which is the recommended and future-proof way to check for timezone-aware datetime dtypes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f800e275-7415-4567-b408-92547d47af88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f800e275-7415-4567-b408-92547d47af88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

