### PR TITLE
Tối ưu hóa gọi api tránh rate limit

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -4286,7 +4286,7 @@ class TradingBotController:
                     return
             
             # 1. Fetch fresh market data
-            market_data = await self._fetch_all_market_data()
+            market_data = await self._fetch_all_market_data(open_markets)
             if not market_data:
                 self.logger.warning("No market data available, skipping cycle")
                 return
@@ -4381,19 +4381,19 @@ class TradingBotController:
             
             await self.discord_manager.send_error_notification("Trading Cycle Error", str(e))
     
-    async def _fetch_all_market_data(self) -> Dict[str, pd.DataFrame]:
-        """Lấy dữ liệu thị trường cho tất cả symbols"""
+    async def _fetch_all_market_data(self, symbols_to_fetch: List[str]) -> Dict[str, pd.DataFrame]:
+        """Lấy dữ liệu thị trường cho các symbols được chỉ định"""
         
         market_data = {}
         
         async with self.api_manager:
             # Fetch data sequentially to avoid rate limiting
-            for symbol in Config.SYMBOLS:
+            for symbol in symbols_to_fetch:
                 symbol_data = {}
                 for timeframe in Config.TIME_FRAMES:
                     try:
                         # Add delay between requests to respect rate limits
-                        await asyncio.sleep(1.0)  # Increased to 1.0s for better rate limit compliance
+                        await asyncio.sleep(1.5)  # Increased to 1.5s for better rate limit compliance
                         df = await self.data_manager.get_fresh_data(symbol, timeframe)
                         if df is not None:
                             symbol_data[timeframe] = df


### PR DESCRIPTION
Optimize API calls to avoid rate limiting by fetching data only for open markets and increasing the delay between requests.

The bot was previously making API requests for all configured symbols regardless of market status, leading to wasted requests and frequent rate limits. This PR modifies `_fetch_all_market_data` to accept a list of `open_markets` and increases the delay between API calls from 1.0s to 1.5s, significantly reducing unnecessary calls and improving rate limit compliance.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed271298-83f9-4231-b2b4-7e212f56609f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed271298-83f9-4231-b2b4-7e212f56609f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

